### PR TITLE
Test to address issue #97 in dasein-cloud-aws

### DIFF
--- a/src/main/java/org/dasein/cloud/test/cloud/StatelessAuthenticationTests.java
+++ b/src/main/java/org/dasein/cloud/test/cloud/StatelessAuthenticationTests.java
@@ -24,20 +24,13 @@ import org.dasein.cloud.CloudException;
 import org.dasein.cloud.CloudProvider;
 import org.dasein.cloud.InternalException;
 import org.dasein.cloud.ProviderContext;
-import org.dasein.cloud.compute.ComputeServices;
 import org.dasein.cloud.test.DaseinTestManager;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TestName;
 
-import java.net.SocketPermission;
-
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * General authentication tests to verify the ability of a Dasein Cloud implementation to authenticate with the cloud


### PR DESCRIPTION
Added an edge-case test to verify providers not requiring the account number for authentication to return a corrected account number from CloudProvider#testContext() - if it was incorrectly configured.
