### PR TITLE
Added username attribute cloud register method. This allows for username...

### DIFF
--- a/src/main/java/org/dasein/cloud/test/DaseinTestManager.java
+++ b/src/main/java/org/dasein/cloud/test/DaseinTestManager.java
@@ -95,7 +95,7 @@ public class DaseinTestManager {
         */
 
         try{
-            String prop, account = "", cloudName = "", endpoint = "", regionId = "", providerName = "";
+            String prop, account = "", cloudName = "", endpoint = "", regionId = "", providerName = "", userName = "";
 
             prop = overrideAccount == null ? System.getProperty("accountNumber") : overrideAccount;
             if( prop != null ) {
@@ -117,8 +117,11 @@ public class DaseinTestManager {
             if( prop != null ) {
                 regionId = prop;
             }
-
-            Cloud cloud = Cloud.register(providerName, cloudName, endpoint, (Class<? extends CloudProvider>) Class.forName(cname));
+            prop = System.getProperty("userName");
+            if( prop != null ) {
+                userName = prop;
+            }
+            Cloud cloud = Cloud.register(providerName, cloudName, endpoint, userName, (Class<? extends CloudProvider>) Class.forName(cname));
 
             ContextRequirements requirements = cloud.buildProvider().getContextRequirements();
             List<ContextRequirements.Field> fields = requirements.getConfigurableValues();

--- a/src/main/java/org/dasein/cloud/test/compute/ComputeResources.java
+++ b/src/main/java/org/dasein/cloud/test/compute/ComputeResources.java
@@ -418,7 +418,7 @@ public class ComputeResources {
                     VirtualMachine vm = (id == null ? null : support.getVirtualMachine(id));
 
                     if( (vm == null || VmState.TERMINATED.equals(vm.getCurrentState())) && provisionIfNull ) {
-                        id = provisionVM(support, label, "Dasein Test " + label, "dsnvm", preferredDataCenterId);
+                        id = provisionVM(support, label, "Dasein Test " + label, provider.getContext().getCloud().getUserName() + "dsnvm", preferredDataCenterId);
                         vm = support.getVirtualMachine(id);
                     }
                     if( vm != null && desiredState != null ) {

--- a/src/main/java/org/dasein/cloud/test/compute/StatefulVMTests.java
+++ b/src/main/java/org/dasein/cloud/test/compute/StatefulVMTests.java
@@ -218,7 +218,7 @@ public class StatefulVMTests {
 
             if( support != null ) {
                 if( support.isSubscribed() ) {
-                    @SuppressWarnings("ConstantConditions") String id = DaseinTestManager.getComputeResources().provisionVM(support, "testLaunch", "Dasein Test Launch", "dsnlaunch", null);
+                    @SuppressWarnings("ConstantConditions") String id = DaseinTestManager.getComputeResources().provisionVM(support, "testLaunch", "Dasein Test Launch", tm.getProvider().getContext().getCloud().getUserName() + "dsnlaunch", null);
 
                     tm.out("Launched", id);
                     assertNotNull("Attempts to provisionVM a virtual machine MUST return a valid ID", id);
@@ -254,7 +254,7 @@ public class StatefulVMTests {
 
             if( support != null ) {
                 if( support.isSubscribed() ) {
-                    @SuppressWarnings("ConstantConditions") Iterable<String> ids = DaseinTestManager.getComputeResources().provisionManyVMs(support, "testLaunch", "Dasein Test Launch", "dsnlaunch", null, 2);
+                    @SuppressWarnings("ConstantConditions") Iterable<String> ids = DaseinTestManager.getComputeResources().provisionManyVMs(support, "testLaunch", "Dasein Test Launch", tm.getProvider().getContext().getCloud().getUserName() + "dsnlaunch", null, 2);
                     int count = 0;
 
                     for( String id : ids ) {


### PR DESCRIPTION
... to be used automatically to name vm's and disk's to ease confusion in development cleanup efforts.

Works in conjunction with update to daesin-cloud-core and daesin-compute-google
