### PR TITLE
Utility classes should not close what they didn't open. This will enable...

### DIFF
--- a/src/main/java/org/dasein/cloud/test/ci/CIResources.java
+++ b/src/main/java/org/dasein/cloud/test/ci/CIResources.java
@@ -104,7 +104,6 @@ public class CIResources {
                 }
             }
         }
-        provider.close();
         return count;
     }
 

--- a/src/main/java/org/dasein/cloud/test/compute/ComputeResources.java
+++ b/src/main/java/org/dasein/cloud/test/compute/ComputeResources.java
@@ -219,7 +219,6 @@ public class ComputeResources {
                 }
             }
         }
-        provider.close();
         return count;
     }
 

--- a/src/main/java/org/dasein/cloud/test/identity/IdentityResources.java
+++ b/src/main/java/org/dasein/cloud/test/identity/IdentityResources.java
@@ -113,7 +113,6 @@ public class IdentityResources {
         catch( Throwable ignore ) {
             // ignore
         }
-        provider.close();
         return count;
     }
 

--- a/src/main/java/org/dasein/cloud/test/network/NetworkResources.java
+++ b/src/main/java/org/dasein/cloud/test/network/NetworkResources.java
@@ -642,7 +642,6 @@ public class NetworkResources {
         } catch( Throwable ignore ) {
             // ignore
         }
-        provider.close();
         return count;
     }
 

--- a/src/main/java/org/dasein/cloud/test/platform/PlatformResources.java
+++ b/src/main/java/org/dasein/cloud/test/platform/PlatformResources.java
@@ -218,7 +218,6 @@ public class PlatformResources {
         catch( Throwable ignore ) {
             // ignore
         }
-        provider.close();
         return count;
     }
 


### PR DESCRIPTION
... us to run with just one CloudProvider instance per run.
